### PR TITLE
fixed so that every way of running parses emotionfile

### DIFF
--- a/src/main/java/goal/tools/AbstractRun.java
+++ b/src/main/java/goal/tools/AbstractRun.java
@@ -16,10 +16,13 @@ import goal.tools.errorhandling.exceptions.GOALRunFailedException;
 import goal.tools.logging.InfoLog;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Collection;
 import java.util.Map;
 
 import krTools.errors.exceptions.ParserException;
+import languageTools.exceptions.relationParser.InvalidEmotionConfigFile;
+import languageTools.parser.relationParser.EmotionConfig;
 import languageTools.program.agent.AgentProgram;
 import languageTools.program.mas.MASProgram;
 import localmessaging.LocalMessaging;
@@ -75,12 +78,17 @@ public abstract class AbstractRun<D extends Debugger, C extends GOALInterpreter<
 	 * @param timeout
 	 *            the number of seconds we should wait for the run to terminate;
 	 *            0 for indefinite.
+	 * @throws InvalidEmotionConfigFile 
+	 * @throws FileNotFoundException 
 	 */
 	public AbstractRun(MASProgram program, Map<File, AgentProgram> agents,
-			long timeout) {
+			long timeout) throws FileNotFoundException, InvalidEmotionConfigFile {
 		this.masProgram = program;
 		this.agentPrograms = agents;
 		this.timeout = timeout;
+		if(program.hasEmotionFile()) {
+			EmotionConfig.parse(program.getEmotionFile());
+		}
 	}
 
 	/**

--- a/src/main/java/goal/tools/PlatformManager.java
+++ b/src/main/java/goal/tools/PlatformManager.java
@@ -429,10 +429,6 @@ public class PlatformManager {
 			throw new ParserException("Invalid MAS file"); //$NON-NLS-1$
 		}
 		addParsedProgram(masFile, masProgram);
-		
-		if(masProgram.hasEmotionFile()) {
-			 EmotionConfig.parse(masProgram.getEmotionFile());
-		}
 
 		// Log messages.
 		boolean hasErrors = false, hasWarnings = false;

--- a/src/main/java/goal/tools/UnitTestRun.java
+++ b/src/main/java/goal/tools/UnitTestRun.java
@@ -1,5 +1,7 @@
 package goal.tools;
 
+import java.io.FileNotFoundException;
+
 import goal.core.agent.AbstractAgentFactory;
 import goal.core.agent.Agent;
 import goal.core.agent.AgentFactory;
@@ -9,6 +11,7 @@ import goal.tools.adapt.Learner;
 import goal.tools.debugger.LoggingObserver;
 import goal.tools.debugger.ObservableDebugger;
 import goal.tools.unittest.UnitTestInterpreter;
+import languageTools.exceptions.relationParser.InvalidEmotionConfigFile;
 import languageTools.program.test.AgentTest;
 import languageTools.program.test.UnitTest;
 
@@ -61,7 +64,7 @@ public class UnitTestRun extends AbstractRun<IDEDebugger, UnitTestInterpreter> {
 	 */
 	private final UnitTest unitTest;
 
-	public UnitTestRun(UnitTest program) {
+	public UnitTestRun(UnitTest program) throws FileNotFoundException, InvalidEmotionConfigFile {
 		super(program.getMasProgram(), program.getAgents(), program
 				.getTimeout());
 		this.unitTest = program;

--- a/src/test/java/goal/parser/unittest/AbstractUnitTestTest.java
+++ b/src/test/java/goal/parser/unittest/AbstractUnitTestTest.java
@@ -10,11 +10,13 @@ import goal.tools.logging.Loggers;
 import goal.tools.unittest.result.UnitTestResult;
 import goal.tools.unittest.result.UnitTestResultFormatter;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Set;
 
 import languageTools.analyzer.test.TestValidator;
 import languageTools.errors.Message;
+import languageTools.exceptions.relationParser.InvalidEmotionConfigFile;
 import languageTools.program.test.UnitTest;
 
 import org.junit.After;
@@ -66,7 +68,7 @@ public class AbstractUnitTestTest {
 	}
 
 	protected UnitTestResult runTest(String testFileName)
-			throws GOALRunFailedException {
+			throws GOALRunFailedException, FileNotFoundException, InvalidEmotionConfigFile {
 		UnitTest unitTest;
 		try {
 			unitTest = setup(testFileName);

--- a/src/test/resources/goal/parser/unittest/CountsTo100Test2.test2g
+++ b/src/test/resources/goal/parser/unittest/CountsTo100Test2.test2g
@@ -1,7 +1,7 @@
 masTest {
 	
 	mas = "counter2.mas2g".
-	timeout = 2.
+	timeout = 5.
 	
 	counter2 {
 		timeOutTest {


### PR DESCRIPTION
Every way of running a mas file should now parse the emotionfile if it is defined (e.g. singlerun, testrun, ....)

closes #34
